### PR TITLE
explicit labels for `confusion_matrix`

### DIFF
--- a/scripts/RF_LR_validation_multiMetricCalculated.py
+++ b/scripts/RF_LR_validation_multiMetricCalculated.py
@@ -14,19 +14,19 @@ feat_labels = np.loadtxt("raw_fList.txt", dtype=np.str)
 
 
 def tn(y_true, y_pred):
-    return confusion_matrix(y_true, y_pred)[0, 0]
+    return confusion_matrix(y_true, y_pred, labels=[0, 1])[0, 0]
 
 
 def fp(y_true, y_pred):
-    return confusion_matrix(y_true, y_pred)[0, 1]
+    return confusion_matrix(y_true, y_pred, labels=[0, 1])[0, 1]
 
 
 def fn(y_true, y_pred):
-    return confusion_matrix(y_true, y_pred)[1, 0]
+    return confusion_matrix(y_true, y_pred, labels=[0, 1])[1, 0]
 
 
 def tp(y_true, y_pred):
-    return confusion_matrix(y_true, y_pred)[1, 1]
+    return confusion_matrix(y_true, y_pred, labels=[0, 1])[1, 1]
 
 
 scoring = {


### PR DESCRIPTION
If explicit labels for the binary classifier are not provided *and* the ground truth equals to the prediction, then `confusion_matrix` sees only a single classifier. This results in `[[x]]` and `[[x]][0, 0]` results in `IndexError`. 

This PR provides explicit labels.